### PR TITLE
Updated tableTools with truncate, added remove null rows, renamed tables.

### DIFF
--- a/Summarizer.php
+++ b/Summarizer.php
@@ -142,8 +142,8 @@
 <?php $_SESSION["selected_symbol"]=$_POST["symbol"] ?>
 
 <footer>
-  <p>working prototype 1.1.1c</p>
-  <p>Date Released: 2018-05-24</p>
+  <p>working prototype 1.1.2b</p>
+  <p>Date Released: 2018-05-26</p>
 
   <nav>
   <a href="SummarizerLogin.html">Login</a>

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -1,0 +1,7 @@
+include.path=${php.global.include.path}
+php.version=PHP_56
+source.encoding=UTF-8
+src.dir=.
+tags.asp=false
+tags.short=false
+web.root=.

--- a/nbproject/project.xml
+++ b/nbproject/project.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://www.netbeans.org/ns/project/1">
+    <type>org.netbeans.modules.php.project</type>
+    <configuration>
+        <data xmlns="http://www.netbeans.org/ns/php-project/1">
+            <name>Summarizer</name>
+        </data>
+    </configuration>
+</project>

--- a/summarizer_styleSheet.css
+++ b/summarizer_styleSheet.css
@@ -40,7 +40,7 @@
 	  margin-right:10%;/*<table style="margin-right:10%"*/
       margin-top:-77px;
       z-index:9999;
-       width:100%;
+       /*width:100%; */
     }
     table th,table td{
         width:200px;

--- a/tableTools.php
+++ b/tableTools.php
@@ -77,6 +77,19 @@
                     die(mysqli_error($connect));
                 }
                 $colExists=implode(",",array_intersect($header,$headerName));
+                
+                  /* This will truncate the temp update table before loading the information into main_table
+                  by Tom Tran 2018-05-26 */
+                $sqlTruncate5="TRUNCATE TABLE temp_update_table;";
+                mysqli_query($connect,$sqlTruncate5);
+                
+                  /* This will delete any NULL rows after the file has been created and inserted into update_table.
+                 which will prevent the issue of empty rows before inserting into main_table. 
+                 by Tom Tran 2018-5-26 */
+                
+                $removeEmptyRow2="DELETE FROM temp_update_table WHERE symbol='' or symbol IS NULL"; 
+                mysqli_query($connect,$removeEmptyRow2);
+                
                 $dropTABLE="DROP TABLE IF EXISTS temp_update_table";
                 mysqli_query($connect,$dropTABLE);
                 $createTable="CREATE TABLE temp_update_table AS SELECT $colExists FROM temp_main_table WHERE 1=0";
@@ -339,11 +352,24 @@
                 $colExists=implode(",",array_intersect($header,$headerName));
                 $dropTABLE="DROP TABLE IF EXISTS update_table";
                 mysqli_query($connect,$dropTABLE);
+                
+                /* This will truncate the update table before loading the information into main_table
+                  by Tom Tran 2018-05-25 */
+                $sqlTruncate4="TRUNCATE TABLE update_table;";
+                mysqli_query($connect,$sqlTruncate4);
+                
+                 /* This will delete any NULL rows after the file has been created and inserted into update_table.
+                 which will prevent the issue of empty rows before inserting into main_table. 
+                 by Tom Tran 2018-5-24 */
+                
+                $removeEmptyRow2="DELETE FROM update_table WHERE symbol='' or symbol IS NULL"; 
+                mysqli_query($connect,$removeEmptyRow2);
+                
                 $createTable="CREATE TABLE update_table AS SELECT $colExists FROM main_table WHERE 1=0";
                 mysqli_query($connect,$createTable);
                 $loadQuery="LOAD DATA LOCAL INFILE '".$_FILES['file']['tmp_name']."' INTO TABLE update_table FIELDS OPTIONALLY ENCLOSED BY '\"' TERMINATED BY ',' LINES TERMINATED BY '\n' IGNORE 1 LINES";
                 mysqli_query($connect,$loadQuery) or die(mysqli_error($connect));
-                $selectSymbolNotExists="SELECT symbol from update_table where symbol not in (select distinct symbol from main_table);";
+                $selectSymbolNotExists="SELECT symbol FROM update_table where symbol NOT IN (SELECT DISTINCT symbol from main_table);";
                 $symbolNotExists=mysqli_query($connect,$selectSymbolNotExists);
                 while($row = mysqli_fetch_assoc($symbolNotExists)){
                     $_SESSION["symbolNotExists"]=$row["symbol"]." ".$_SESSION["symbolNotExists"];
@@ -407,7 +433,7 @@
                 $dropTABLE="DROP TABLE IF EXISTS append_table";
                 mysqli_query($connect,$dropTABLE);
                 
-                                
+                
                 /* This will truncate the append table before loading the information into main_table
                   by Tom Tran 2018-05-24 */
                 $sqlTruncate3="TRUNCATE TABLE append_table;";

--- a/tableTools.php
+++ b/tableTools.php
@@ -24,7 +24,7 @@
             $filename=explode(".",$_FILES["file"]["name"]);
             if($filename[1]=="csv"){
                 $handle=fopen($_FILES["file"]["tmp_name"],"r");
-                $sql2="TRUNCATE TABLE main_table_testL";
+                $sql2="TRUNCATE TABLE temp_main_table";
                 mysqli_query($connect,$sql2);
                 $header=array();
                 $newHeader=array();
@@ -38,15 +38,16 @@
                 }
                 $colExists=implode(",",array_intersect($header,$headerName));
                 // $_SESSION["colNotExists"]=$colExists;
-                $loadQuery="LOAD DATA LOCAL INFILE '".$_FILES['file']['tmp_name']."' INTO TABLE main_table_testL FIELDS OPTIONALLY ENCLOSED BY '\"' TERMINATED BY ',' LINES TERMINATED BY '\n' IGNORE 1 LINES";
+                $loadQuery="LOAD DATA LOCAL INFILE '".$_FILES['file']['tmp_name']."' INTO TABLE temp_main_table FIELDS OPTIONALLY ENCLOSED BY '\"' TERMINATED BY ',' LINES TERMINATED BY '\n' IGNORE 1 LINES;";
                 mysqli_query($connect,$loadQuery) or die(mysqli_error($connect));
-                $findDuplicatedSymbol="SELECT symbol, COUNT(*) c FROM main_table_testL GROUP BY symbol HAVING c > 1;";
+                $findDuplicatedSymbol="SELECT symbol, COUNT(*) c FROM temp_main_table GROUP BY symbol HAVING c > 1;";
                 $duplicatedSymbol=mysqli_query($connect,$findDuplicatedSymbol);
                 while($row = mysqli_fetch_assoc($duplicatedSymbol)){
                     $_SESSION["duplicates"]=$row["symbol"]." ".$_SESSION["duplicates"];
                 };
-                $_SESSION["table"]="main_table_testL";
-                $removeEmptyRow="DELETE FROM main_table_testL WHERE symbol='' or symbol is null"; 
+                $_SESSION["table"]="temp_main_table";
+                $removeEmptyRow="DELETE FROM temp_main_table WHERE symbol='' or symbol IS NULL"; 
+                
                 mysqli_query($connect,$removeEmptyRow);
                 fclose($handle);               
                 mysqli_close($connect);
@@ -76,32 +77,32 @@
                     die(mysqli_error($connect));
                 }
                 $colExists=implode(",",array_intersect($header,$headerName));
-                $dropTABLE="DROP TABLE IF EXISTS update_table_testL";
+                $dropTABLE="DROP TABLE IF EXISTS temp_update_table";
                 mysqli_query($connect,$dropTABLE);
-                $createTable="CREATE TABLE update_table_testL AS SELECT $colExists FROM main_table_testL WHERE 1=0";
+                $createTable="CREATE TABLE temp_update_table AS SELECT $colExists FROM temp_main_table WHERE 1=0";
                 mysqli_query($connect,$createTable);
-                $loadQuery="LOAD DATA LOCAL INFILE '".$_FILES['file']['tmp_name']."' INTO TABLE update_table_testL FIELDS OPTIONALLY ENCLOSED BY '\"' TERMINATED BY ',' LINES TERMINATED BY '\n' IGNORE 1 LINES";
+                $loadQuery="LOAD DATA LOCAL INFILE '".$_FILES['file']['tmp_name']."' INTO TABLE temp_update_table FIELDS OPTIONALLY ENCLOSED BY '\"' TERMINATED BY ',' LINES TERMINATED BY '\n' IGNORE 1 LINES;";
                 mysqli_query($connect,$loadQuery) or die(mysqli_error($connect));
-                $selectSymbolNotExists="SELECT symbol from update_table_testL where symbol not in (select distinct symbol from main_table_testL);";
+                $selectSymbolNotExists="SELECT symbol from temp_update_table where symbol not in (select distinct symbol from temp_main_table);";
                 $symbolNotExists=mysqli_query($connect,$selectSymbolNotExists);
                 while($row = mysqli_fetch_assoc($symbolNotExists)){
                     $_SESSION["symbolNotExists"]=$row["symbol"]." ".$_SESSION["symbolNotExists"];
                 };
-                $findDuplicatedSymbol="SELECT symbol, COUNT(*) c FROM update_table_testL GROUP BY symbol HAVING c > 1;";
+                $findDuplicatedSymbol="SELECT symbol, COUNT(*) c FROM temp_update_table GROUP BY symbol HAVING c > 1;";
                 $duplicatedSymbol=mysqli_query($connect,$findDuplicatedSymbol);
                 while($row = mysqli_fetch_assoc($duplicatedSymbol)){
                     $_SESSION["duplicates"]=$row["symbol"]." ".$_SESSION["duplicates"];
                 };
                 $set=array();
                 for($z=0;$z<count($header);$z++){
-                    $set[$z]="main_table_testL.".$header[$z]."="."update_table_testL.".$header[$z];
+                    $set[$z]="temp_main_table.".$header[$z]."="."temp_update_table.".$header[$z];
                 }
                 $condition=implode(",",$set);
-                $updateTable="UPDATE main_table_testL, update_table_testL
+                $updateTable="UPDATE temp_main_table, temp_update_table
                 SET $condition
-                WHERE main_table_testL.symbol = update_table_testL.symbol;";
+                WHERE temp_main_table.symbol = temp_update_table.symbol;";
                 mysqli_query($connect,$updateTable);
-                $_SESSION["table"]="main_table_testL";
+                $_SESSION["table"]="temp_main_table";
                 fclose($handle);
                 header("Location:loader.php");
             }
@@ -118,6 +119,17 @@
             $filename=explode(".",$_FILES["file"]["name"]);
             if($filename[1]=="csv"){
                 $handle=fopen($_FILES["file"]["tmp_name"],"r");
+                
+                 /* This will truncate the append table test before loading the information into temp_append_table
+                     by Tom Tran 2018-05-24 */
+                $sqlTruncate="TRUNCATE TABLE temp_append_table;";
+                mysqli_query($connect,$sqlTruncate);
+                
+                 /* This will truncate the temp_main_table before loading the information into temp_main_table
+                    by Tom Tran 2018-05-24 */
+                $sqlTruncate2="TRUNCATE TABLE temp_main_table;";
+                mysqli_query($connect,$sqlTruncate2);
+                
                 $header=array();
                 $newHeader=array();
                 $headerName=["symbol", "industry", "market_cap", "current_price", "biotech", "penny_stock", "active", "catalysts", "last_earnings", "next_earnings", "bo_ah", "intern", "cash", "burn", "related_tickers", "analysis_date", "analysis_price", "variation", "1st_price_target", "1st_upside", "2nd_price_target", "2nd_upside", "downside_risk", "rank", "confidence", "worst_case", "target_weight", "target_position", "actual_position", "actual_weight", "weight_difference", "strategy", "discussion", "notes", "last_update","id"];
@@ -129,29 +141,39 @@
                     die(mysqli_error($connect));
                 }
                 $colExists=implode(",",array_intersect($header,$headerName));
-                $dropTABLE="DROP TABLE IF EXISTS append_table_testL";
+                $dropTABLE="DROP TABLE IF EXISTS temp_append_table";
                 mysqli_query($connect,$dropTABLE);
-                $createTable="CREATE TABLE append_table_testL AS SELECT $colExists FROM main_table_testL WHERE 1=0";
+                $createTable="CREATE TABLE temp_append_table AS SELECT $colExists FROM temp_main_table WHERE 1=0";
                 mysqli_query($connect,$createTable);
-                $loadQuery="LOAD DATA LOCAL INFILE '".$_FILES['file']['tmp_name']."' INTO TABLE append_table_testL FIELDS OPTIONALLY ENCLOSED BY '\"' TERMINATED BY ',' LINES TERMINATED BY '\n' IGNORE 1 LINES";
+                $loadQuery="LOAD DATA LOCAL INFILE '".$_FILES['file']['tmp_name']."' INTO TABLE temp_append_table FIELDS OPTIONALLY ENCLOSED BY '\"' TERMINATED BY ',' LINES TERMINATED BY '\n' IGNORE 1 LINES;";
                 mysqli_query($connect,$loadQuery) or die(mysqli_error($connect));
-                $findDuplicatedSymbol="SELECT symbol, COUNT(*) c FROM append_table_testL GROUP BY symbol HAVING c > 1;";
+                
+            
+                /* This will delete any NULL rows after the file has been created and inserted into temp_append_table.
+                 which will prevent the issue of empty rows before inserting into temp_main_table.
+                 by Tom Tran 2018-05-24 */
+                
+                $removeEmptyRow="DELETE FROM temp_append_table WHERE symbol='' or symbol IS NULL"; 
+                mysqli_query($connect,$removeEmptyRow);
+                
+                $findDuplicatedSymbol="SELECT symbol, COUNT(*) c FROM temp_append_table GROUP BY symbol HAVING c > 1;";
                 $duplicatedSymbol=mysqli_query($connect,$findDuplicatedSymbol);
                 while($result = mysqli_fetch_assoc($duplicatedSymbol)){
                     $_SESSION["duplicates"]=$result["symbol"]." ".$_SESSION["duplicates"];
                     header("location:loader.php");
                     die(mysqli_error($connect));
                 };
-                $selectSymbolExists="SELECT symbol from append_table_testL where symbol in (select distinct symbol from main_table_testL);";
+                $selectSymbolExists="SELECT symbol from temp_append_table where symbol in (select distinct symbol from temp_main_table);";
                 $symbolExists=mysqli_query($connect,$selectSymbolExists);
                 while($row = mysqli_fetch_assoc($symbolExists)){
                     $_SESSION["duplicates"]=$row["symbol"]." ".$_SESSION["duplicates"];
                     header("location:loader.php");
                     die(mysqli_error($connect));
                 };
-           
-                $insertQuery="INSERT INTO main_table_testL (symbol, industry, market_cap, current_price, biotech, penny_stock, active, catalysts, last_earnings, next_earnings, bo_ah, intern, cash, burn, related_tickers, analysis_date, analysis_price, variation, 1st_price_target, 1st_upside, 2nd_price_target, 2nd_upside, downside_risk, rank, confidence, worst_case, target_weight, target_position, actual_position, actual_weight, weight_difference, strategy, discussion, notes, last_update,id)
-                SELECT * FROM append_table_testL WHERE append_table_testL.symbol NOT IN (SELECT symbol from main_table_testL)";
+                
+                // This will take the data that is found in the temp_append_table and INSERT it into the temp_main_table.
+                $insertQuery="INSERT INTO temp_main_table (symbol, industry, market_cap, current_price, biotech, penny_stock, active, catalysts, last_earnings, next_earnings, bo_ah, intern, cash, burn, related_tickers, analysis_date, analysis_price, variation, 1st_price_target, 1st_upside, 2nd_price_target, 2nd_upside, downside_risk, rank, confidence, worst_case, target_weight, target_position, actual_position, actual_weight, weight_difference, strategy, discussion, notes, last_update,id)
+                SELECT * FROM temp_append_table;";  // WHERE append_table_testL.symbol NOT IN (SELECT symbol from main_table_testL)";
                 mysqli_query($connect,$insertQuery);
                 fclose($handle);
                 mysqli_close($connect);
@@ -166,7 +188,7 @@
         {
         die('Could not connect: ' . mysqli_error());
         }
-        $query = "SELECT * FROM main_table_testL";
+        $query = "SELECT * FROM temp_main_table";
         if (!$result = mysqli_query($con, $query)) {
             exit(mysqli_error($con));
         };
@@ -180,7 +202,7 @@
         $time=time();
         $date=date("Y-m-d h:i:sa",time());
         header('Content-Type: text/csv; charset=utf-8');
-        header('Content-Disposition: attachment; filename=main_table_testL_'.$date.'.csv');
+        header('Content-Disposition: attachment; filename=temp_main_table_'.$date.'.csv');
         $output = fopen('php://output', 'w');
         fputcsv($output, array("symbol", "industry", "market_cap", "current_price", "biotech", "penny_stock", "active", "catalysts", "last_earnings", "next_earnings", "bo_ah", "intern", "cash", "burn", "related_tickers", "analysis_date", "analysis_price", "variation", "1st_price_target", "1st_upside","2nd_price_target","2nd_upside", "downside_risk", "rank", "confidence", "worst_case", "target_weight", "target_position", "actual_position", "actual_weight", "weight_difference", "strategy", "discussion", "notes", "last_update"));
         if (count($users) > 0) {
@@ -359,7 +381,7 @@
         if($_FILES["file"]["name"]){
             $filename=explode(".",$_FILES["file"]["name"]);
             if($filename[1]=="csv"){
-                $handle=fopen($_FILES["file"]["tmp_name"],"r");
+                $handle=fopen($_FILES["file"]["tmp_name"],"r");      
                 $user=$_SESSION['uname'];
                 date_default_timezone_set('America/Chicago');
                 $date=date("Y-m-d h:i:sa",time());
@@ -384,10 +406,26 @@
                 $colExists=implode(",",array_intersect($header,$headerName));
                 $dropTABLE="DROP TABLE IF EXISTS append_table";
                 mysqli_query($connect,$dropTABLE);
-                $createTable="CREATE TABLE append_table AS SELECT $colExists FROM main_table WHERE 1=0";
-                mysqli_query($connect,$createTable);
+                
+                                
+                /* This will truncate the append table before loading the information into main_table
+                  by Tom Tran 2018-05-24 */
+                $sqlTruncate3="TRUNCATE TABLE append_table;";
+                mysqli_query($connect,$sqlTruncate3);
+                
+                
+                $createTable="CREATE TABLE append_table AS SELECT $colExists FROM main_table WHERE 1=0;";
+                mysqli_query($connect,$createTable);          
                 $loadQuery="LOAD DATA LOCAL INFILE '".$_FILES['file']['tmp_name']."' INTO TABLE append_table FIELDS OPTIONALLY ENCLOSED BY '\"' TERMINATED BY ',' LINES TERMINATED BY '\n' IGNORE 1 LINES";
                 mysqli_query($connect,$loadQuery) or die(mysqli_error($connect));
+                
+                 /* This will delete any NULL rows after the file has been created and inserted into append_table.
+                 which will prevent the issue of empty rows before inserting into main_table. 
+                 by Tom Tran 2018-5-24 */
+                
+                $removeEmptyRow="DELETE FROM append_table WHERE symbol='' or symbol IS NULL"; 
+                mysqli_query($connect,$removeEmptyRow);
+                
                 $findDuplicatedSymbol="SELECT symbol, COUNT(*) c FROM append_table GROUP BY symbol HAVING c > 1;";
                 $duplicatedSymbol=mysqli_query($connect,$findDuplicatedSymbol);
                 while($result = mysqli_fetch_assoc($duplicatedSymbol)){
@@ -403,7 +441,7 @@
                     die(mysqli_error($connect));
                 };
                 $insertQuery="INSERT INTO main_table (symbol, industry, market_cap, current_price, biotech, penny_stock, active, catalysts, last_earnings, next_earnings, bo_ah, intern, cash, burn, related_tickers, analysis_date, analysis_price, variation, 1st_price_target, 1st_upside, 2nd_price_target, 2nd_upside, downside_risk, rank, confidence, worst_case, target_weight, target_position, actual_position, actual_weight, weight_difference, strategy, discussion, notes, last_update,id)
-                SELECT * FROM append_table WHERE append_table.symbol NOT IN (SELECT symbol from main_table)";
+                SELECT * FROM append_table;";           // WHERE append_table.symbol NOT IN (SELECT symbol from main_table)";
                 mysqli_query($connect,$insertQuery);
                 fclose($handle);
                 $userAction="appended a CSV file";


### PR DESCRIPTION
… append and main testing tables.

In tableTools.php

Under all the code for Programmers:

Changed append_table_testL and main_table_testL and update_table_testL to temp_append_table, temp_main_table, and temp_update_table.

Under Append for Programmers:

Added truncate function to clear out both temp_append_table and temp_main_table

Added remove null rows function to clear out null rows from the append_table before inserting into temp_main_table.

Under Admin / Maintainer

Added truncate function to clear out the append_table before inserting more symbols and to prevent duplicate error.

Added remove null rows to append_table before inserting into main_table to avoid enterint null rows and duplicate error.

In summarizer_styleSheet.css

commented out width100% for now